### PR TITLE
Disable CORS request as it tries to jsonp

### DIFF
--- a/mobileapp/components/index.js
+++ b/mobileapp/components/index.js
@@ -106,6 +106,7 @@ io = window.io = SailsIOClient(SocketIOClient);
 // (you have to specify the host and port of the Sails backend when using this library from Node.js)
 io.sails.url = DEFAULT_API_SERVER_BASE_URL;
 io.sails.query = 'nosession=true';
+io.sails.useCORSRouteToGetCookie = false;
 // ============================================================================================
 
 


### PR DESCRIPTION
Cannot execute `jsonp` method in react-native.

If we don't set useCORSRouteToGetCookie to false it will get past this block: https://github.com/balderdashy/sails.io.js/blob/master/sails.io.js#L860

Then it will try to do this `jsonp` block:

https://github.com/balderdashy/sails.io.js/blob/master/sails.io.js#L478-L500

And this needs `document`. So it will fail.

I have to manually feed the cookie into sails.io.js like this:

```
// be sure to set 
// io.sails.initialConnectionHeaders = {
//     'cookie': SAILS_SID_COOKIE
//   };
```
You probably don't need to set CSRF, but if the users server requires it, then they need to add that in:

```
// io.sails.initialConnectionHeaders = {
//     'x-csrf-token': CSRF_TOKEN,
//     'cookie': SAILS_SID_COOKIE
//   };
```